### PR TITLE
Return all matching results

### DIFF
--- a/lib/archangel/driver/filesystem.rb
+++ b/lib/archangel/driver/filesystem.rb
@@ -27,10 +27,10 @@ module Archangel
       end
 
       def fetch(id)
-        Dir["#{@root}/*.json"].each do |file|
+        Dir["#{@root}/*.json"].map do |file|
           data = JSON.parse(File.read(file))
-          break data if data["id"] == id
-        end
+          data["id"] == id ? data : nil
+        end.compact
       end
 
     end

--- a/lib/archangel/driver/guardtime.rb
+++ b/lib/archangel/driver/guardtime.rb
@@ -19,16 +19,12 @@ module Archangel
 
       def fetch(id)
         results = gt_search(id)
-
-        result_count = results['content'] ? results['content'].length : 0
-        if (result_count == 0)
-          raise "No results found for #{id}"
-        end
-        if (result_count > 1)
-          raise "Multiple results found for #{id}"
-        end
-
-        results['content'][0]['metadata']
+        return [] unless results.has_key? 'content'
+        # Return metadata structs for all content
+        # This probably needs to change to include the
+        # hashes later on.
+        results['content'].map{|x| x['metadata']}
+        
       end # fetch
     end # Guardtime
   end # Driver

--- a/lib/archangel/driver/guardtimeV2.rb
+++ b/lib/archangel/driver/guardtimeV2.rb
@@ -19,17 +19,13 @@ module Archangel
 
       def fetch(id)
         gt_ids = gt_search(id)
-
-        result_count = gt_ids['ids'] ? gt_ids['ids'].length : 0
-        if (result_count == 0)
-          raise "No results found for #{id}"
+        return [] unless gt_ids.has_key? 'ids'
+        # Return metadata structs for all content
+        # This probably needs to change to include the
+        # hashes later on.
+        gt_ids['ids'].map do |id|
+          gt_fetch(id)['metadata']
         end
-        if (result_count > 1)
-          raise "Multiple results found for #{id}"
-        end
-
-        result = gt_fetch(gt_ids['ids'][0])
-        result['metadata']
       end # fetch
 
       private

--- a/spec/storage_driver_spec.rb
+++ b/spec/storage_driver_spec.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples "a storage backend" do
 
   it "fetches payload given id", :vcr => { :cassette_name => "#{@cassette_name}-fetch" } do
     data.each do |id, payload, timestamp|
-      read = driver.fetch(id)
+      read = driver.fetch(id)[0]
 
       expect(read["id"]).to eq id
       expect(read["payload"]).to eq payload


### PR DESCRIPTION
We may have multiple results for a single ID, over time. Let's return them all, or a simple empty array if there are none.